### PR TITLE
Update Celestrak module

### DIFF
--- a/space/tle/celestrak.py
+++ b/space/tle/celestrak.py
@@ -12,7 +12,7 @@ from .db import TleDb
 log = logging.getLogger(__name__)
 
 TMP_FOLDER = TMP_FOLDER / "celestrak"
-CELESTRAK_URL = "http://celestrak.com/NORAD/elements/"
+CELESTRAK_URL = "http://celestrak.org/NORAD/elements/"
 PAGE_LIST_CONFIG = ("celestrak", "page-list")
 DEFAULT_FILES = [
     "stations.txt",

--- a/space/tle/celestrak.py
+++ b/space/tle/celestrak.py
@@ -2,6 +2,7 @@ import logging
 import asyncio
 import aiohttp
 import async_timeout
+import re
 import requests
 from bs4 import BeautifulSoup
 
@@ -84,8 +85,10 @@ def fetch_list():
     files = []
     bs = BeautifulSoup(page.text, features="lxml")
     for link in bs.body.find_all("a"):
-        if "href" in link.attrs and link["href"].endswith(".txt"):
-            files.append(link.get("href"))
+        if "href" in link.attrs:
+            linkmatch = re.fullmatch(r"gp\.php\?GROUP=([A-Za-z0-9\-]+)&FORMAT=tle", link["href"])
+            if linkmatch is not None:
+                files.append(linkmatch.group(1) + ".txt")
 
     log.info("%d celestrak files found", len(files))
 


### PR DESCRIPTION
Celestrak changed there website.

 * Switch from `.com` to `.org` top level domain
 * File link references changed

This PR fixes the fetch logic, so we are able to fetch data and the file list again.