### PR TITLE
fix tle : split database update in chunks

### DIFF
--- a/space/tle/db.py
+++ b/space/tle/db.py
@@ -194,7 +194,10 @@ class TleDb:
                     entities.append(entity)
 
             if entities:
-                TleModel.insert_many(entities).execute()
+                # Split up the list into chunks of at most 999 items, as SQlite
+                # can only handle a limited number of elements per operation.
+                for i in range(0, len(entities), 999):
+                    TleModel.insert_many(entities[i:i + 999]).execute()
             elif i is None:
                 raise ValueError("{} contains no TLE".format(src))
 

--- a/space/tle/db.py
+++ b/space/tle/db.py
@@ -196,8 +196,8 @@ class TleDb:
             if entities:
                 # Split up the list into chunks of at most 999 items, as SQlite
                 # can only handle a limited number of elements per operation.
-                for i in range(0, len(entities), 999):
-                    TleModel.insert_many(entities[i:i + 999]).execute()
+                for idx in range(0, len(entities), 999):
+                    TleModel.insert_many(entities[idx:idx + 999]).execute()
             elif i is None:
                 raise ValueError("{} contains no TLE".format(src))
 


### PR DESCRIPTION
When fetching TLE data from Celestrak the following error occurs:

```
$ space tle celestrak fetch                            
Retrieving TLEs from celestrak
argos.txt    0/8
tdrss.txt    0/31
noaa.txt    0/22
visual.txt    0/165
resource.txt    0/180
sarsat.txt    0/78
geo.txt    0/548
beidou.txt    0/50
stations.txt    0/51
tle-new.txt    0/184
weather.txt    0/47
x-comm.txt    0/18
glo-ops.txt    0/26
gps-ops.txt    0/31
goes.txt    0/18
intelsat.txt    0/66
dmc.txt    0/10
raduga.txt    0/43
iridium-NEXT.txt    0/75
amateur.txt    0/116
iridium.txt    0/31
geodetic.txt    0/8
analyst.txt    0/381
other.txt    0/2
nnss.txt    0/18
radar.txt    0/11
sbas.txt    0/17
globalstar.txt    0/85
galileo.txt    0/28
military.txt    0/5
molniya.txt    0/35
musson.txt    0/9
cubesat.txt    0/150
engineering.txt    0/29
education.txt    0/6
ses.txt    0/68
planet.txt    0/199
science.txt    0/60
orbcomm.txt    0/59
other-comm.txt    0/25
spire.txt    0/117
gorizont.txt    0/33
4764
0 new satellites registered, 0 satellites updated
too many SQL variables
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/peewee.py", line 3216, in execute_sql
    cursor.execute(sql, params or ())
sqlite3.OperationalError: too many SQL variables

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.10/space", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.10/site-packages/space/__main__.py", line 152, in main
    func(*args)
  File "/usr/lib/python3.10/site-packages/space/tle/__init__.py", line 105, in space_tle
    celestrak.fetch(*args["<file>"])
  File "/usr/lib/python3.10/site-packages/space/tle/celestrak.py", line 73, in fetch
    loop.run_until_complete(_fetch(files))
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/usr/lib/python3.10/site-packages/space/tle/celestrak.py", line 156, in _fetch
    await asyncio.gather(*tasks)
  File "/usr/lib/python3.10/site-packages/space/tle/celestrak.py", line 126, in _fetch_file
    TleDb().insert(text, filename)
  File "/usr/lib/python3.10/site-packages/space/tle/db.py", line 198, in insert
    TleModel.insert_many(entities).execute()
  File "/usr/lib/python3.10/site-packages/peewee.py", line 1946, in inner
    return method(self, database, *args, **kwargs)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 2017, in execute
    return self._execute(database)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 2817, in _execute
    return super(Insert, self)._execute(database)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 2530, in _execute
    cursor = database.execute(self)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 3229, in execute
    return self.execute_sql(sql, params, commit=commit)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 3213, in execute_sql
    with __exception_wrapper__:
  File "/usr/lib/python3.10/site-packages/peewee.py", line 2989, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 191, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.10/site-packages/peewee.py", line 3216, in execute_sql
    cursor.execute(sql, params or ())
peewee.OperationalError: too many SQL variables
```

SQlite allows only a limited number of inserts per statement. This fix prevents the error by splitting the fetched elements into chucks.