### PR TITLE
fix deprecation warnings for `iter_entry_points`

### DIFF
--- a/space/wspace.py
+++ b/space/wspace.py
@@ -8,7 +8,26 @@ import subprocess
 from pathlib import Path
 from datetime import datetime
 from contextlib import contextmanager
-from pkg_resources import iter_entry_points
+
+if sys.version_info.minor >= 8:
+    from importlib.metadata import entry_points as vanilla_entry_points
+
+    if sys.version_info.minor >= 10:
+        entry_points = vanilla_entry_points
+    else:
+        # Creating a custom filtering function to circumvent the lack of filtering
+        # of the entry_points function in python 3.8 and 3.9
+        def entry_points(group=None):
+            entries = vanilla_entry_points()
+            if group:
+                entries = entries[group]
+            return entries
+
+else:
+    from pkg_resources import iter_entry_points
+
+    entry_points = lambda group=None: iter_entry_points(group)
+
 from peewee import SqliteDatabase
 
 from .utils import docopt, humanize
@@ -144,7 +163,7 @@ class Workspace:
             raise ValueError("Unknown workspace command '{}'".format(cmd))
 
         # Each command is responsible of its own initialization, logging and error handling
-        for entry in sorted(iter_entry_points("space.wshook"), key=lambda x: x.name):
+        for entry in sorted(entry_points("space.wshook"), key=lambda x: x.name):
             entry.load()(cmd)
 
     @classmethod


### PR DESCRIPTION
Invoking `space` with recent Python versions produces a deprecation warning.

```
$ space
/usr/lib/python3.13/site-packages/space/wspace.py:11: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
```

This PR removes the deprecated `iter_entry_points`-import.

Consider removing support for deprecated Python versions (3.9 and earlier). References to `iter_entry_points` can then be removed at all.