### PR TITLE
remove deprecated `async_timeout`-package for Python 3.11 and newer

### DIFF
--- a/space/tle/celestrak.py
+++ b/space/tle/celestrak.py
@@ -1,10 +1,15 @@
 import logging
 import asyncio
 import aiohttp
-import async_timeout
 import re
 import requests
 from bs4 import BeautifulSoup
+import sys
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 from .common import TMP_FOLDER
 from ..wspace import ws
@@ -116,7 +121,7 @@ async def _fetch_file(session, filename):
 
     When the page is totally retrieved, the function will call insert
     """
-    with async_timeout.timeout(30):
+    async with timeout(30):
         async with session.get(CELESTRAK_URL.format(filename)) as response:
             text = await response.text()
 


### PR DESCRIPTION
The `async_timeout`-package is deprecated as its function is included in Python 3.11 or newer. Invoking `space` with a recent python interpreter will produce an exception.

```
$ space tle celestrak fetch
/usr/lib/python3.13/site-packages/space/wspace.py:11: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import iter_entry_points
Retrieving TLEs from celestrak
0 new satellites registered, 0 satellites updated
'Timeout' object does not support the context manager protocol
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.13/space", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/space/__main__.py", line 178, in main
    func(*args)
    ~~~~^^^^^^^
  File "/usr/lib/python3.13/site-packages/space/tle/__init__.py", line 105, in space_tle
    celestrak.fetch(*args["<file>"])
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/space/tle/celestrak.py", line 75, in fetch
    loop.run_until_complete(_fetch(files))
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/space/tle/celestrak.py", line 159, in _fetch
    mysum = await asyncio.gather(*tasks)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/space/tle/celestrak.py", line 119, in _fetch_file
    with async_timeout.timeout(30):
         ~~~~~~~~~~~~~~~~~~~~~^^^^
TypeError: 'Timeout' object does not support the context manager protocol
```